### PR TITLE
Add of release notes in the UpdateAvailableDialog

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
@@ -3,6 +3,7 @@ package com.github.javiersantos.appupdater;
 import android.content.Context;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.github.javiersantos.appupdater.enums.AppUpdaterError;
@@ -22,7 +23,7 @@ public class AppUpdater {
     private String xmlUrl;
     private Integer showEvery;
     private Boolean showAppUpdated;
-    private String titleUpdate, descriptionUpdate, btnUpdate, btnDisable; // Update available
+    private String titleUpdate, descriptionUpdate, btnDismiss, btnUpdate, btnDisable; // Update available
     private String titleNoUpdate, descriptionNoUpdate; // Update not available
     private int iconResId;
 
@@ -40,6 +41,7 @@ public class AppUpdater {
         this.titleUpdate = context.getResources().getString(R.string.appupdater_update_available);
         this.titleNoUpdate = context.getResources().getString(R.string.appupdater_update_not_available);
         this.btnUpdate = context.getResources().getString(R.string.appupdater_btn_update);
+        this.btnDismiss = context.getResources().getString(R.string.appupdater_btn_dismiss);
         this.btnDisable = context.getResources().getString(R.string.appupdater_btn_disable);
     }
 
@@ -225,13 +227,13 @@ public class AppUpdater {
                     if (UtilsLibrary.isAbleToShow(successfulChecks, showEvery)) {
                         switch (display) {
                             case DIALOG:
-                                UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(context, update.getLatestVersion(), Display.DIALOG), btnUpdate, btnDisable, updateFrom, update.getUrlToDownload());
+                                UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(context, update, Display.DIALOG), btnDismiss, btnUpdate, btnDisable, updateFrom, update.getUrlToDownload());
                                 break;
                             case SNACKBAR:
-                                UtilsDisplay.showUpdateAvailableSnackbar(context, getDescriptionUpdate(context, update.getLatestVersion(), Display.SNACKBAR), UtilsLibrary.getDurationEnumToBoolean(duration), updateFrom, update.getUrlToDownload());
+                                UtilsDisplay.showUpdateAvailableSnackbar(context, getDescriptionUpdate(context, update, Display.SNACKBAR), UtilsLibrary.getDurationEnumToBoolean(duration), updateFrom, update.getUrlToDownload());
                                 break;
                             case NOTIFICATION:
-                                UtilsDisplay.showUpdateAvailableNotification(context, context.getResources().getString(R.string.appupdater_update_available), getDescriptionUpdate(context, update.getLatestVersion(), Display.NOTIFICATION), updateFrom, update.getUrlToDownload(), iconResId);
+                                UtilsDisplay.showUpdateAvailableNotification(context, context.getResources().getString(R.string.appupdater_update_available), getDescriptionUpdate(context, update, Display.NOTIFICATION), updateFrom, update.getUrlToDownload(), iconResId);
                                 break;
                         }
                     }
@@ -272,17 +274,20 @@ public class AppUpdater {
         void onFailed(AppUpdaterError error);
     }
 
-    private String getDescriptionUpdate(Context context, String version, Display display) {
+    private String getDescriptionUpdate(Context context, Update update, Display display) {
         if (descriptionUpdate == null) {
             switch (display) {
                 case DIALOG:
-                    return String.format(context.getResources().getString(R.string.appupdater_update_available_description_dialog), version, UtilsLibrary.getAppName(context));
+                    if (!TextUtils.isEmpty(update.getReleaseNotes()))
+                        return String.format(context.getResources().getString(R.string.appupdater_update_available_description_dialog_before_release_notes), update.getLatestVersion(), update.getReleaseNotes());
+                    else
+                        return String.format(context.getResources().getString(R.string.appupdater_update_available_description_dialog), update.getLatestVersion(), UtilsLibrary.getAppName(context));
 
                 case SNACKBAR:
-                    return String.format(context.getResources().getString(R.string.appupdater_update_available_description_snackbar), version);
+                    return String.format(context.getResources().getString(R.string.appupdater_update_available_description_snackbar), update.getLatestVersion());
 
                 case NOTIFICATION:
-                    return String.format(context.getResources().getString(R.string.appupdater_update_available_description_notification), version, UtilsLibrary.getAppName(context));
+                    return String.format(context.getResources().getString(R.string.appupdater_update_available_description_notification), update.getLatestVersion(), UtilsLibrary.getAppName(context));
 
             }
         }

--- a/library/src/main/java/com/github/javiersantos/appupdater/RssHandler.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/RssHandler.java
@@ -33,6 +33,8 @@ class RssHandler extends DefaultHandler {
         if (this.update != null) {
             if (localName.equals("latestVersion")) {
                 update.setLatestVersion(builder.toString().trim());
+            } else if (localName.equals("releaseNotes")) {
+                update.setReleaseNotes(builder.toString().trim());
             } else if (localName.equals("url")) {
                 try {
                     update.setUrlToDownload(new URL(builder.toString().trim()));

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
@@ -17,14 +17,14 @@ import java.net.URL;
 
 class UtilsDisplay {
 
-    static void showUpdateAvailableDialog(final Context context, String title, String content, String btnPositive, String btnNeutral, final UpdateFrom updateFrom, final URL apk) {
+    static void showUpdateAvailableDialog(final Context context, String title, String content, String btnNegative, String btnPositive, String btnNeutral, final UpdateFrom updateFrom, final URL apk) {
         final LibraryPreferences libraryPreferences = new LibraryPreferences(context);
 
         new MaterialDialog.Builder(context)
                 .title(title)
                 .content(content)
                 .positiveText(btnPositive)
-                .negativeText(context.getResources().getString(android.R.string.cancel))
+                .negativeText(btnNegative)
                 .neutralText(btnNeutral)
                 .onPositive(new MaterialDialog.SingleButtonCallback() {
                     @Override

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -193,7 +193,7 @@ class UtilsLibrary {
             }
         }
 
-        return new Update(version, getUpdateURL(context, updateFrom, gitHub));
+        return new Update(version, null, getUpdateURL(context, updateFrom, gitHub));
     }
 
     static Update getLatestAppVersionXml(String urlXml) {

--- a/library/src/main/java/com/github/javiersantos/appupdater/objects/Update.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/objects/Update.java
@@ -4,13 +4,15 @@ import java.net.URL;
 
 public class Update {
     private String version;
+    private String releaseNotes;
     private URL apk;
 
     public Update() {}
 
-    public Update(String latestVersion, URL apk) {
+    public Update(String latestVersion, String releaseNotes, URL apk) {
         this.version = latestVersion;
         this.apk = apk;
+        this.releaseNotes = releaseNotes;
     }
 
     public String getLatestVersion() {
@@ -19,6 +21,14 @@ public class Update {
 
     public void setLatestVersion(String latestVersion) {
         this.version = latestVersion;
+    }
+
+    public String getReleaseNotes() {
+        return releaseNotes;
+    }
+
+    public void setReleaseNotes(String releaseNotes) {
+        this.releaseNotes = releaseNotes;
     }
 
     public URL getUrlToDownload() {

--- a/library/src/main/res/values-fr/strings.xml
+++ b/library/src/main/res/values-fr/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="appupdater_update_available">Nouvelle mise à jour disponible!</string>
     <string name="appupdater_update_available_description_dialog">La mise à jour %1$s est disponible. En téléchargeant cette version de l\'application, vous aurez accès aux dernières fonctionnalités et améliorations de %2$s.</string>
+    <string name="appupdater_update_available_description_dialog_before_release_notes">"La mise à jour %1$s est disponible.\nVous pouvez bénéficier des fonctionnalités suivantes :\n%2$s"</string>
     <string name="appupdater_update_available_description_snackbar">Mise à jour %1$s disponible!</string>
     <string name="appupdater_update_available_description_notification">La mise à jour %1$s de %2$s est disponible.</string>
     <string name="appupdater_update_not_available">Aucune mise à jour disponible</string>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="appupdater_update_available">New update available!</string>
     <string name="appupdater_update_available_description_dialog">Update %1$s is available to download. Downloading the latest update you will get the latest features, improvements and bug fixes for %2$s.</string>
+    <string name="appupdater_update_available_description_dialog_before_release_notes">Update %1$s is available to download.\nYou can get this new features :\n%2$s"</string>
     <string name="appupdater_update_available_description_snackbar">Update %1$s is available!</string>
     <string name="appupdater_update_available_description_notification">Update %1$s of %2$s is available to download</string>
     <string name="appupdater_update_not_available">No updates available</string>


### PR DESCRIPTION
Release notes can be added in the dialog shown when an update is available. Like this :
```xml
<AppUpdater>
  <update>
    <latestVersion>1.2.2</latestVersion>
    <url>https://github.com/javiersantos/AppUpdater/releases</url>
    <releaseNotes>
- First evolution
- Second evolution
- Bug fixes
	</releaseNotes>
  </update>
</AppUpdater>
```
And there is a new message to introduce the updates.

The dismiss button label can be customize in the string.xml.