### PR TITLE
Added possibility for custom click listeners

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
@@ -2,6 +2,7 @@ package com.github.javiersantos.appupdater;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
@@ -31,6 +32,7 @@ public class AppUpdater implements IAppUpdater {
     private String titleNoUpdate, descriptionNoUpdate; // Update not available
     private int iconResId;
     private UtilsAsync.LatestAppVersion latestAppVersion;
+    private DialogInterface.OnClickListener btnUpdateClickListener, btnDismissClickListener, btnDisableClickListener;
 
     private AlertDialog alertDialog;
     private Snackbar snackbar;
@@ -285,6 +287,24 @@ public class AppUpdater implements IAppUpdater {
     }
 
     @Override
+    public AppUpdater setButtonUpdateClickListener(final DialogInterface.OnClickListener clickListener) {
+        btnUpdateClickListener = clickListener;
+        return this;
+    }
+
+    @Override
+    public AppUpdater setButtonDismissClickListener(final DialogInterface.OnClickListener clickListener) {
+        btnDismissClickListener = clickListener;
+        return this;
+    }
+
+    @Override
+    public AppUpdater setButtonDoNotShowAgainClickListener(final DialogInterface.OnClickListener clickListener) {
+        btnDisableClickListener = clickListener;
+        return this;
+    }
+
+    @Override
     public AppUpdater setIcon(@DrawableRes int iconRes) {
         this.iconResId = iconRes;
         return this;
@@ -310,7 +330,10 @@ public class AppUpdater implements IAppUpdater {
                     if (UtilsLibrary.isAbleToShow(successfulChecks, showEvery)) {
                         switch (display) {
                             case DIALOG:
-                                alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(context, update, Display.DIALOG), btnDismiss, btnUpdate, btnDisable, updateFrom, update.getUrlToDownload());
+                                final DialogInterface.OnClickListener updateClickListener = btnUpdateClickListener == null ? new UpdateClickListener(context, updateFrom, update.getUrlToDownload()) : btnUpdateClickListener;
+                                final DialogInterface.OnClickListener disableClickListener = btnDisableClickListener == null ? new DisableClickListener(context) : btnDisableClickListener;
+
+                                alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(context, update, Display.DIALOG), btnDismiss, btnUpdate, btnDisable, updateClickListener, btnDismissClickListener, disableClickListener);
                                 alertDialog.show();
                                 break;
                             case SNACKBAR:

--- a/library/src/main/java/com/github/javiersantos/appupdater/DisableClickListener.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/DisableClickListener.java
@@ -1,0 +1,22 @@
+package com.github.javiersantos.appupdater;
+
+import android.content.Context;
+import android.content.DialogInterface;
+
+/**
+ * Click listener for the "Do Not Show Again" button of the update dialog. <br/>
+ * Extend this class to add custom actions to the button on top of the default functionality.
+ */
+public class DisableClickListener implements DialogInterface.OnClickListener {
+
+    private final LibraryPreferences libraryPreferences;
+
+    public DisableClickListener(final Context context) {
+        libraryPreferences = new LibraryPreferences(context);
+    }
+
+    @Override
+    public void onClick(final DialogInterface dialog, final int which) {
+        libraryPreferences.setAppUpdaterShow(false);
+    }
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/IAppUpdater.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/IAppUpdater.java
@@ -1,5 +1,6 @@
 package com.github.javiersantos.appupdater;
 
+import android.content.DialogInterface;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
@@ -318,6 +319,32 @@ public interface IAppUpdater {
      * @return this
      */
     AppUpdater setButtonDoNotShowAgain(@StringRes int textResource);
+
+    /**
+     * Sets a custom click listener for the "Update" button when a new update is available.
+     * In order to maintain the default functionality, extend {@link UpdateClickListener}
+     *
+     * @param clickListener for update button
+     * @return this
+     */
+    AppUpdater setButtonUpdateClickListener(DialogInterface.OnClickListener clickListener);
+
+    /**
+     * Sets a custom click listener for the "Dismiss" button when a new update is available.
+     *
+     * @param clickListener for dismiss button
+     * @return this
+     */
+    AppUpdater setButtonDismissClickListener(DialogInterface.OnClickListener clickListener);
+
+    /**
+     * Sets a custom click listener for the "Don't show again" button when a new update is available. <br/>
+     * In order to maintain the default functionality, extend {@link DisableClickListener}
+     *
+     * @param clickListener for disable button
+     * @return this
+     */
+    AppUpdater setButtonDoNotShowAgainClickListener(DialogInterface.OnClickListener clickListener);
 
     /**
      * Sets the resource identifier for the small notification icon

--- a/library/src/main/java/com/github/javiersantos/appupdater/UpdateClickListener.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UpdateClickListener.java
@@ -1,0 +1,30 @@
+package com.github.javiersantos.appupdater;
+
+import android.content.Context;
+import android.content.DialogInterface;
+
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
+
+import java.net.URL;
+
+/**
+ * Click listener for the "Update" button of the update dialog. <br/>
+ * Extend this class to add custom actions to the button on top of the default functionality.
+ */
+public class UpdateClickListener implements DialogInterface.OnClickListener {
+
+    private final Context context;
+    private final UpdateFrom updateFrom;
+    private final URL apk;
+
+    public UpdateClickListener(final Context context, final UpdateFrom updateFrom, final URL apk) {
+        this.context = context;
+        this.updateFrom = updateFrom;
+        this.apk = apk;
+    }
+
+    @Override
+    public void onClick(final DialogInterface dialog, final int which) {
+        UtilsLibrary.goToUpdate(context, updateFrom, apk);
+    }
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
@@ -17,28 +17,13 @@ import java.net.URL;
 
 class UtilsDisplay {
 
-    static AlertDialog showUpdateAvailableDialog(final Context context, String title, String content, String btnNegative, String btnPositive, String btnNeutral, final UpdateFrom updateFrom, final URL apk) {
-        final LibraryPreferences libraryPreferences = new LibraryPreferences(context);
-
+    static AlertDialog showUpdateAvailableDialog(final Context context, String title, String content, String btnNegative, String btnPositive, String btnNeutral, final DialogInterface.OnClickListener updateClickListener, final DialogInterface.OnClickListener dismissClickListener, final DialogInterface.OnClickListener disableClickListener) {
         return new AlertDialog.Builder(context)
                 .setTitle(title)
                 .setMessage(content)
-                .setPositiveButton(btnPositive, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        UtilsLibrary.goToUpdate(context, updateFrom, apk);
-                    }
-                })
-                .setNegativeButton(btnNegative, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {}
-                })
-                .setNeutralButton(btnNeutral, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        libraryPreferences.setAppUpdaterShow(false);
-                    }
-                }).create();
+                .setPositiveButton(btnPositive, updateClickListener)
+                .setNegativeButton(btnNegative, dismissClickListener)
+                .setNeutralButton(btnNeutral, disableClickListener).create();
     }
 
     static AlertDialog showUpdateNotAvailableDialog(final Context context, String title, String content) {


### PR DESCRIPTION
Added the possibility to add a custom click listener for each of the buttons of the update dialog.
- `setButtonUpdateClickListener(DialogInterface.OnClickListener clickListener) `
- `setButtonDismissClickListener(DialogInterface.OnClickListener clickListener)`
- `setButtonDoNotShowAgainClickListener(DialogInterface.OnClickListener clickListener)`

Developers can overwrite the default functionality by creating a new OnClickListener, or add their own functionality on top of the default functionality by extending the provided `UpdateClickListener` and `DisableClickListener`.

This feature could be useful to developers who would like to enforce updates, because they could provide some logic when the user would dismiss the update dialog (i.e. simply `finish()` the current activity).