### PR TITLE
Never let UtilsAsync.LatestAppVersion async job crash the app

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsAsync.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsAsync.java
@@ -63,28 +63,33 @@ class UtilsAsync {
 
         @Override
         protected Update doInBackground(Void... voids) {
-            if (updateFrom == UpdateFrom.XML || updateFrom == UpdateFrom.JSON) {
-                Update update = UtilsLibrary.getLatestAppVersion(updateFrom, xmlOrJsonUrl);
-                if (update != null) {
-                    return update;
-                } else {
-                    AppUpdaterError error = updateFrom == UpdateFrom.XML ? AppUpdaterError.XML_ERROR
-                            : AppUpdaterError.JSON_ERROR;
+            try {
+                if (updateFrom == UpdateFrom.XML || updateFrom == UpdateFrom.JSON) {
+                    Update update = UtilsLibrary.getLatestAppVersion(updateFrom, xmlOrJsonUrl);
+                    if (update != null) {
+                        return update;
+                    } else {
+                        AppUpdaterError error = updateFrom == UpdateFrom.XML ? AppUpdaterError.XML_ERROR
+                                                                             : AppUpdaterError.JSON_ERROR;
 
-                    if (listener != null) {
-                        listener.onFailed(error);
+                        if (listener != null) {
+                            listener.onFailed(error);
+                        }
+                        cancel(true);
+                        return null;
                     }
-                    cancel(true);
-                    return null;
-                }
-            } else {
-                Context context = contextRef.get();
-                if (context != null) {
-                    return UtilsLibrary.getLatestAppVersionHttp(context, updateFrom, gitHub);
                 } else {
-                    cancel(true);
-                    return null;
+                    Context context = contextRef.get();
+                    if (context != null) {
+                        return UtilsLibrary.getLatestAppVersionHttp(context, updateFrom, gitHub);
+                    } else {
+                        cancel(true);
+                        return null;
+                    }
                 }
+            } catch (Exception ex) {
+                cancel(true);
+                return null;
             }
         }
 


### PR DESCRIPTION
I got crash reports like this from the field

```
Fatal Exception: java.lang.RuntimeException: An error occured while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:299)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:352)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:219)
       at java.util.concurrent.FutureTask.run(FutureTask.java:239)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:230)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
       at java.lang.Thread.run(Thread.java:838)
Caused by java.lang.ArrayIndexOutOfBoundsException: src.length=0 srcPos=0 dst.length=23197 dstPos=0 length=18184
       at java.lang.System.arraycopy(System.java)
       at java.lang.AbstractStringBuilder.enlargeBuffer(AbstractStringBuilder.java:95)
       at java.lang.AbstractStringBuilder.append0(AbstractStringBuilder.java:124)
       at java.lang.StringBuilder.append(StringBuilder.java:271)
       at java.io.BufferedReader.readLine(BufferedReader.java:417)
       at com.github.javiersantos.appupdater.UtilsLibrary.getLatestAppVersionHttp(SourceFile:151)
       at com.github.javiersantos.appupdater.UtilsAsync$LatestAppVersion.doInBackground(SourceFile:83)
       at com.github.javiersantos.appupdater.UtilsAsync$LatestAppVersion.doInBackground(SourceFile:15)
       at android.os.AsyncTask$2.call(AsyncTask.java:287)
       at java.util.concurrent.FutureTask.run(FutureTask.java:234)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:230)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
       at java.lang.Thread.run(Thread.java:838)
```

I suspect there are something very wrong with the user device but nonetheless AppUpdater should never ever crash. In this case it crashes in the async task spawned by the library itself. The app developer has no chance to catch and handle the unchecked exception.

AppUpdater should be super-defensive. This PR should achieve it.