### PR TITLE
Add required permissions to library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.javiersantos.appupdater" />
+    package="com.github.javiersantos.appupdater">
+    
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+</manifest>


### PR DESCRIPTION
Gradle manifest merger will include these permissions in application manifest. User doesn't need to add permission manually to application's AndroidManifest.xml