### PR TITLE
Filter GitHub response to the latest release

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -113,7 +113,7 @@ class UtilsLibrary {
                 res = String.format(Config.PLAY_STORE_URL, getAppPackageName(context), Locale.getDefault().getLanguage());
                 break;
             case GITHUB:
-                res = Config.GITHUB_URL + gitHub.getGitHubUser() + "/" + gitHub.getGitHubRepo() + "/releases";
+                res = Config.GITHUB_URL + gitHub.getGitHubUser() + "/" + gitHub.getGitHubRepo() + "/releases/latest";
                 break;
             case AMAZON:
                 res = Config.AMAZON_URL + getAppPackageName(context);


### PR DESCRIPTION
Changed url of GitHub release page to the one containing the [*latest* release](https://help.github.com/articles/linking-to-releases/#linking-to-the-latest-release).

Fixes #129.

Has been tested in dhebbeker/AppUpdater@cd212c44aa4a2ac28dc7865ed72e952806610153