### PR TITLE
render version string countability more imperturbable

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -64,19 +64,22 @@ class UtilsLibrary {
     }
 
     static Boolean isUpdateAvailable(Update installedVersion, Update latestVersion) {
-        Boolean res = false;
-
         if (latestVersion.getLatestVersionCode() != null && latestVersion.getLatestVersionCode() > 0) {
             return latestVersion.getLatestVersionCode() > installedVersion.getLatestVersionCode();
         } else {
             if (!TextUtils.equals(installedVersion.getLatestVersion(), "0.0.0.0") && !TextUtils.equals(latestVersion.getLatestVersion(), "0.0.0.0")) {
-                Version installed = new Version(installedVersion.getLatestVersion());
-                Version latest = new Version(latestVersion.getLatestVersion());
-                res = installed.compareTo(latest) < 0;
-            }
+                try
+                {
+                    final Version installed = new Version(installedVersion.getLatestVersion());
+                    final Version latest = new Version(latestVersion.getLatestVersion());
+                    return installed.compareTo(latest) < 0;
+                } catch (Exception e)
+                {
+                    e.printStackTrace();
+                    return false;
+                }
+            } else return false;
         }
-
-        return res;
     }
 
     static Boolean isStringAVersion(String version) {

--- a/library/src/main/java/com/github/javiersantos/appupdater/objects/Version.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/objects/Version.java
@@ -1,7 +1,6 @@
 package com.github.javiersantos.appupdater.objects;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 public class Version implements Comparable<Version> {
     private String version;
@@ -10,14 +9,14 @@ public class Version implements Comparable<Version> {
         return this.version;
     }
 
-    public Version(String version) {
-        final String TAG = "AppUpdater";
-        if (version == null)
-            Log.e(TAG, "Version can not be null");
-        version = version.replaceAll("[^0-9?!\\.]", "");
-        if (!version.matches("[0-9]+(\\.[0-9]+)*"))
-            Log.e(TAG, "Invalid version format");
-        this.version = version;
+    public Version(@NonNull final String version) throws Exception
+    {
+        String trimmedVersion = version.replaceAll("[^0-9?!\\.]", "");
+        // replace all empty version number-parts with zeros
+        trimmedVersion = trimmedVersion.replaceAll("\\.(\\.|$)", "\\.0$1");
+        if (!trimmedVersion.matches("[0-9]+(\\.[0-9]+)*"))
+            throw new Exception("Invalid version format. Original: `" + version + "` trimmed: `" + trimmedVersion + "`");
+        this.version = trimmedVersion;
     }
 
     @Override


### PR DESCRIPTION
# Preamble
A version string shall be composed of version partitions which are concatenated by dots. A version partition can be for example the major version number.

# Current situation
Non-number characters are removed in version number partitions.

# Change
Empty version number partitions are replaced with 0. In case the resulting version string is invalid a checked exception is thrown. This exception is catched in UtilsLibrary.java.

# Effect
A version string is transformed from `2.1.3.alpha.42.RC` to `2.1.3..42.` to `2.1.3.0.42.0`. Without this change an integer conversion error occurs when attempting to convert the empty version partitions.