### PR TITLE
Refine cutting of a preceding v in version string

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -215,8 +215,9 @@ class UtilsLibrary {
                     if (splitGitHub.length > 1) {
                         splitGitHub = splitGitHub[1].split("(\")");
                         version = splitGitHub[0].trim();
-                        if (version.contains("v")) { // Some repo uses vX.X.X
-                            splitGitHub = version.split("(v)");
+                        if (version.startsWith("v"))
+                        { // Some repo uses vX.X.X
+                            splitGitHub = version.split("(v)", 2);
                             version = splitGitHub[1].trim();
                         }
                     }


### PR DESCRIPTION
A version string is split by a `v` only once and only if it is at the beginning of the string.