### PR TITLE
Using view as Snackbar container instead android.R.id.content.

### DIFF
--- a/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java
@@ -10,6 +10,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 
 import com.github.javiersantos.appupdater.enums.AppUpdaterError;
 import com.github.javiersantos.appupdater.enums.Display;
@@ -20,6 +21,7 @@ import com.github.javiersantos.appupdater.objects.GitHub;
 import com.github.javiersantos.appupdater.objects.Update;
 
 public class AppUpdater implements IAppUpdater {
+    private View view;
     private Context context;
     private LibraryPreferences libraryPreferences;
     private Display display;
@@ -73,6 +75,12 @@ public class AppUpdater implements IAppUpdater {
     @Override
     public AppUpdater setDuration(Duration duration) {
         this.duration = duration;
+        return this;
+    }
+
+    @Override
+    public AppUpdater setView(View view) {
+        this.view = view;
         return this;
     }
 
@@ -348,7 +356,7 @@ public class AppUpdater implements IAppUpdater {
                                 alertDialog.show();
                                 break;
                             case SNACKBAR:
-                                snackbar = UtilsDisplay.showUpdateAvailableSnackbar(context, getDescriptionUpdate(context, update, Display.SNACKBAR), UtilsLibrary.getDurationEnumToBoolean(duration), updateFrom, update.getUrlToDownload());
+                                snackbar = UtilsDisplay.showUpdateAvailableSnackbar(view, getDescriptionUpdate(context, update, Display.SNACKBAR), UtilsLibrary.getDurationEnumToBoolean(duration), updateFrom, update.getUrlToDownload());
                                 snackbar.show();
                                 break;
                             case NOTIFICATION:
@@ -365,7 +373,7 @@ public class AppUpdater implements IAppUpdater {
                             alertDialog.show();
                             break;
                         case SNACKBAR:
-                            snackbar = UtilsDisplay.showUpdateNotAvailableSnackbar(context, getDescriptionNoUpdate(context), UtilsLibrary.getDurationEnumToBoolean(duration));
+                            snackbar = UtilsDisplay.showUpdateNotAvailableSnackbar(view, getDescriptionNoUpdate(context), UtilsLibrary.getDurationEnumToBoolean(duration));
                             snackbar.show();
                             break;
                         case NOTIFICATION:

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
@@ -1,6 +1,5 @@
 package com.github.javiersantos.appupdater;
 
-import android.app.Activity;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -38,8 +37,8 @@ class UtilsDisplay {
                 .create();
     }
 
-    static Snackbar showUpdateAvailableSnackbar(final Context context, String content, Boolean indefinite, final UpdateFrom updateFrom, final URL apk) {
-        Activity activity = (Activity) context;
+    static Snackbar showUpdateAvailableSnackbar(View view, String content, Boolean indefinite, final UpdateFrom updateFrom, final URL apk) {
+        final Context context = view.getContext();
         int snackbarTime = indefinite ? Snackbar.LENGTH_INDEFINITE : Snackbar.LENGTH_LONG;
 
         /*if (indefinite) {
@@ -48,7 +47,7 @@ class UtilsDisplay {
             snackbarTime = Snackbar.LENGTH_LONG;
         }*/
 
-        Snackbar snackbar = Snackbar.make(activity.findViewById(android.R.id.content), content, snackbarTime);
+        Snackbar snackbar = Snackbar.make(view, content, snackbarTime);
         snackbar.setAction(context.getResources().getString(R.string.appupdater_btn_update), new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -58,8 +57,7 @@ class UtilsDisplay {
         return snackbar;
     }
 
-    static Snackbar showUpdateNotAvailableSnackbar(final Context context, String content, Boolean indefinite) {
-        Activity activity = (Activity) context;
+    static Snackbar showUpdateNotAvailableSnackbar(View view, String content, Boolean indefinite) {
         int snackbarTime = indefinite ? Snackbar.LENGTH_INDEFINITE : Snackbar.LENGTH_LONG;
 
         /*if (indefinite) {
@@ -69,7 +67,7 @@ class UtilsDisplay {
         }*/
 
 
-        return Snackbar.make(activity.findViewById(android.R.id.content), content, snackbarTime);
+        return Snackbar.make(view, content, snackbarTime);
     }
 
     static void showUpdateAvailableNotification(Context context, String title, String content, UpdateFrom updateFrom, URL apk, int smallIconResourceId) {

--- a/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IAppUpdater.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IAppUpdater.java
@@ -4,6 +4,7 @@ import android.content.DialogInterface;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.view.View;
 
 import com.github.javiersantos.appupdater.AppUpdater;
 import com.github.javiersantos.appupdater.DisableClickListener;
@@ -42,6 +43,15 @@ public interface IAppUpdater {
      * @see com.github.javiersantos.appupdater.enums.Duration
      */
     AppUpdater setDuration(Duration duration);
+
+
+    /**
+     * Set the view where Snackbar will be placed.
+     *
+     * @param view view where Snackbar will be placed.
+     * @return this
+     */
+    AppUpdater setView(View view);
 
     /**
      * Set the user and repo where the releases are uploaded. You must upload your updates as a release in order to work properly tagging them as vX.X.X or X.X.X.


### PR DESCRIPTION
Using android.R.id.content as container is a problem when working with bottom navigation bar. So, this PR allows to pass a view that will be the snackbar container.