### PR TITLE
Customizable display

### DIFF
--- a/app/src/main/java/com/github/javiersantos/appupdater/demo/CustomDisplay.java
+++ b/app/src/main/java/com/github/javiersantos/appupdater/demo/CustomDisplay.java
@@ -1,0 +1,30 @@
+package com.github.javiersantos.appupdater.demo;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import com.github.javiersantos.appupdater.Displays.BaseDisplay;
+import com.github.javiersantos.appupdater.objects.Update;
+
+public class CustomDisplay extends BaseDisplay {
+
+    public CustomDisplay(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onShow(Update update) {
+        super.onShow(update);
+        Toast.makeText(context.getApplicationContext(),getDescriptionUpdate(), Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onUpdated(Update update) {
+        Toast.makeText(context.getApplicationContext(),getDescriptionNoUpdate(), Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void dismiss() {
+        return;
+    }
+}

--- a/app/src/main/java/com/github/javiersantos/appupdater/demo/MainActivity.java
+++ b/app/src/main/java/com/github/javiersantos/appupdater/demo/MainActivity.java
@@ -121,6 +121,17 @@ public class MainActivity extends AppCompatActivity {
                         .start();
             }
         });
+
+        binding.included.customDisplay.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                new AppUpdater(mContext)
+                        .setUpdateFrom(UpdateFrom.JSON)
+                        .setDisplayUpdater(new CustomDisplay(mContext))
+                        .setUpdateJSON("https://raw.githubusercontent.com/javiersantos/AppUpdater/master/app/update-changelog.json")
+                        .start();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -179,6 +179,29 @@
 
             </android.support.v7.widget.CardView>
 
+            <android.support.v7.widget.CardView
+                android:id="@+id/custom_display"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="5dp"
+                android:foreground="?android:attr/selectableItemBackground">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="@string/custom_update_display"
+                        android:textAllCaps="true" />
+                </LinearLayout>
+
+            </android.support.v7.widget.CardView>
+
         </LinearLayout>
 
     </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="btn_dialog_google_play">Show dialog (Google Play)</string>
     <string name="btn_snackbar_google_play">Show snackbar (Google Play)</string>
     <string name="btn_notification_google_play">Show notification (Google Play)</string>
+    <string name="custom_update_display">Show custom display</string>
 
     <string name="settings_check_for_updates">Check for updates</string>
     <string name="settings_check_for_updates_summary">Check for new versions using AppUpdater library.</string>

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/BaseDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/BaseDisplay.java
@@ -1,0 +1,64 @@
+package com.github.javiersantos.appupdater.Displays;
+
+import android.content.Context;
+
+import com.github.javiersantos.appupdater.R;
+import com.github.javiersantos.appupdater.UtilsLibrary;
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.github.javiersantos.appupdater.interfaces.IUpdateDisplay;
+import com.github.javiersantos.appupdater.objects.Update;
+
+import java.net.URL;
+
+public abstract class BaseDisplay implements IUpdateDisplay {
+    public Context context;
+    String descriptionText,descriptionNoUpdateText;
+    UpdateFrom updateFrom;
+    URL updateUrl;
+
+    public BaseDisplay(Context context) {
+        this.context = context;
+        descriptionNoUpdateText = String.format(context.getResources().getString(R.string.appupdater_update_not_available_description), UtilsLibrary.getAppName(context));
+    }
+
+    @Override
+    public void onShow(Update update) {
+        if (descriptionText == null){
+            descriptionText = String.format(context.getResources().getString(R.string.appupdater_update_available_description_notification), update.getLatestVersion(), UtilsLibrary.getAppName(context));
+        }
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionNoUpdate(String text) {
+        this.descriptionNoUpdateText = text;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionUpdate(String text) {
+        this.descriptionText = text;
+        return this;
+    }
+
+    @Override
+    public String getDescriptionUpdate() {
+        return descriptionText;
+    }
+
+    @Override
+    public String getDescriptionNoUpdate() {
+        return descriptionNoUpdateText;
+    }
+
+    @Override
+    public URL getUpdateUrl(Update update) {
+        return update.getUrlToDownload();
+    }
+
+    @Override
+    public IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom) {
+        this.updateFrom = updateFrom;
+        return this;
+    }
+
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/BaseDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/BaseDisplay.java
@@ -61,4 +61,8 @@ public abstract class BaseDisplay implements IUpdateDisplay {
         return this;
     }
 
+    @Override
+    public UpdateFrom getUpdateFrom() {
+        return updateFrom;
+    }
 }

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/DialogDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/DialogDisplay.java
@@ -3,32 +3,30 @@ package com.github.javiersantos.appupdater.Displays;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.support.v7.app.AlertDialog;
+import android.text.TextUtils;
 
 import com.github.javiersantos.appupdater.DisableClickListener;
 import com.github.javiersantos.appupdater.R;
 import com.github.javiersantos.appupdater.UpdateClickListener;
 import com.github.javiersantos.appupdater.UtilsDisplay;
-import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.github.javiersantos.appupdater.UtilsLibrary;
 import com.github.javiersantos.appupdater.interfaces.IUpdateDisplay;
+import com.github.javiersantos.appupdater.objects.Update;
 
-import java.net.URL;
-
-public class DialogDisplay implements IUpdateDisplay {
-    private Context context;
+public class DialogDisplay extends BaseDisplay {
     private AlertDialog alertDialog;
     private Boolean isDialogCancelable;
     private DialogInterface.OnClickListener btnUpdateClickListener, btnDismissClickListener, btnDisableClickListener;
     String titleUpdate;
     String titleNoUpdate;
-    String descriptionText,descriptionNoUpdateText;
     String btnDismiss;
     String btnDisable;
     String btnUpdate;
-    UpdateFrom updateFrom;
-    URL updateUrl;
+    String descriptionUpdate;
+
 
     public DialogDisplay(Context context) {
-        this.context = context;
+        super(context);
         this.titleUpdate = context.getResources().getString(R.string.appupdater_update_available);
         this.titleNoUpdate = context.getResources().getString(R.string.appupdater_update_not_available);
         this.btnDismiss = context.getResources().getString(R.string.appupdater_btn_dismiss);
@@ -38,20 +36,32 @@ public class DialogDisplay implements IUpdateDisplay {
     }
 
     @Override
-    public void onShow() {
+    public void onShow(Update update) {
+        super.onShow(update);
         final DialogInterface.OnClickListener updateClickListener = btnUpdateClickListener == null ? new UpdateClickListener(context, updateFrom, updateUrl) : btnUpdateClickListener;
         final DialogInterface.OnClickListener disableClickListener = btnDisableClickListener == null ? new DisableClickListener(context) : btnDisableClickListener;
 
-        alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, descriptionText, btnDismiss, btnUpdate, btnDisable, updateClickListener, btnDismissClickListener, disableClickListener);
+        alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, getDescriptionUpdate(update), btnDismiss, btnUpdate, btnDisable, updateClickListener, btnDismissClickListener, disableClickListener);
         alertDialog.setCancelable(isDialogCancelable);
         alertDialog.show();
     }
 
     @Override
-    public void onUpdated() {
-        alertDialog = UtilsDisplay.showUpdateNotAvailableDialog(context, titleNoUpdate, descriptionText);
+    public void onUpdated(Update update) {
+        alertDialog = UtilsDisplay.showUpdateNotAvailableDialog(context, titleNoUpdate, getDescriptionUpdate(update));
         alertDialog.setCancelable(isDialogCancelable);
         alertDialog.show();
+    }
+
+    public String getDescriptionUpdate(Update update) {
+        if (update.getReleaseNotes() != null && !TextUtils.isEmpty(update.getReleaseNotes())) {
+            if (TextUtils.isEmpty(descriptionUpdate))
+                return update.getReleaseNotes();
+            else
+                return String.format(context.getResources().getString(R.string.appupdater_update_available_description_dialog_before_release_notes), update.getLatestVersion(), update.getReleaseNotes());
+        } else {
+            return String.format(context.getResources().getString(R.string.appupdater_update_available_description_dialog), update.getLatestVersion(), UtilsLibrary.getAppName(context));
+        }
     }
 
     public Boolean getDialogCancelable() {
@@ -60,30 +70,6 @@ public class DialogDisplay implements IUpdateDisplay {
 
     public IUpdateDisplay setDialogCancelable(Boolean dialogCancelable) {
         isDialogCancelable = dialogCancelable;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setDescriptionUpdate(String text) {
-        this.descriptionText = text;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setDescriptionNoUpdate(String text) {
-        this.descriptionNoUpdateText = text;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setUpdateUrl(URL url) {
-        this.updateUrl = url;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom) {
-        this.updateFrom = updateFrom;
         return this;
     }
 

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/DialogDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/DialogDisplay.java
@@ -1,0 +1,96 @@
+package com.github.javiersantos.appupdater.Displays;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+
+import com.github.javiersantos.appupdater.DisableClickListener;
+import com.github.javiersantos.appupdater.R;
+import com.github.javiersantos.appupdater.UpdateClickListener;
+import com.github.javiersantos.appupdater.UtilsDisplay;
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.github.javiersantos.appupdater.interfaces.IUpdateDisplay;
+
+import java.net.URL;
+
+public class DialogDisplay implements IUpdateDisplay {
+    private Context context;
+    private AlertDialog alertDialog;
+    private Boolean isDialogCancelable;
+    private DialogInterface.OnClickListener btnUpdateClickListener, btnDismissClickListener, btnDisableClickListener;
+    String titleUpdate;
+    String titleNoUpdate;
+    String descriptionText,descriptionNoUpdateText;
+    String btnDismiss;
+    String btnDisable;
+    String btnUpdate;
+    UpdateFrom updateFrom;
+    URL updateUrl;
+
+    public DialogDisplay(Context context) {
+        this.context = context;
+        this.titleUpdate = context.getResources().getString(R.string.appupdater_update_available);
+        this.titleNoUpdate = context.getResources().getString(R.string.appupdater_update_not_available);
+        this.btnDismiss = context.getResources().getString(R.string.appupdater_btn_dismiss);
+        this.btnDisable = context.getResources().getString(R.string.appupdater_btn_disable);
+        this.btnUpdate = context.getResources().getString(R.string.appupdater_btn_update);
+        isDialogCancelable = true;
+    }
+
+    @Override
+    public void onShow() {
+        final DialogInterface.OnClickListener updateClickListener = btnUpdateClickListener == null ? new UpdateClickListener(context, updateFrom, updateUrl) : btnUpdateClickListener;
+        final DialogInterface.OnClickListener disableClickListener = btnDisableClickListener == null ? new DisableClickListener(context) : btnDisableClickListener;
+
+        alertDialog = UtilsDisplay.showUpdateAvailableDialog(context, titleUpdate, descriptionText, btnDismiss, btnUpdate, btnDisable, updateClickListener, btnDismissClickListener, disableClickListener);
+        alertDialog.setCancelable(isDialogCancelable);
+        alertDialog.show();
+    }
+
+    @Override
+    public void onUpdated() {
+        alertDialog = UtilsDisplay.showUpdateNotAvailableDialog(context, titleNoUpdate, descriptionText);
+        alertDialog.setCancelable(isDialogCancelable);
+        alertDialog.show();
+    }
+
+    public Boolean getDialogCancelable() {
+        return isDialogCancelable;
+    }
+
+    public IUpdateDisplay setDialogCancelable(Boolean dialogCancelable) {
+        isDialogCancelable = dialogCancelable;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionUpdate(String text) {
+        this.descriptionText = text;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionNoUpdate(String text) {
+        this.descriptionNoUpdateText = text;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setUpdateUrl(URL url) {
+        this.updateUrl = url;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom) {
+        this.updateFrom = updateFrom;
+        return this;
+    }
+
+    @Override
+    public void dismiss() {
+        if (alertDialog != null && alertDialog.isShowing()) {
+            alertDialog.dismiss();
+        }
+    }
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/NotificationDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/NotificationDisplay.java
@@ -1,0 +1,34 @@
+package com.github.javiersantos.appupdater.Displays;
+
+import android.content.Context;
+
+import com.github.javiersantos.appupdater.R;
+import com.github.javiersantos.appupdater.UtilsDisplay;
+import com.github.javiersantos.appupdater.objects.Update;
+
+public class NotificationDisplay extends BaseDisplay {
+    private String titleUpdate;
+    private String titleNoUpdate;
+    private int iconResId;
+
+    public NotificationDisplay(Context context) {
+        super(context);
+        this.iconResId = R.drawable.ic_stat_name;
+    }
+
+    @Override
+    public void onShow(Update update) {
+        super.onShow(update);
+        UtilsDisplay.showUpdateAvailableNotification(context, titleUpdate, descriptionText, updateFrom, getUpdateUrl(update), iconResId);
+    }
+
+    @Override
+    public void onUpdated(Update update) {
+        UtilsDisplay.showUpdateNotAvailableNotification(context, titleNoUpdate, descriptionNoUpdateText, iconResId);
+    }
+
+    @Override
+    public void dismiss() {
+        return;
+    }
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/SnackbarDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/SnackbarDisplay.java
@@ -1,0 +1,81 @@
+package com.github.javiersantos.appupdater.Displays;
+
+import android.content.Context;
+import android.support.design.widget.Snackbar;
+
+import com.github.javiersantos.appupdater.UtilsDisplay;
+import com.github.javiersantos.appupdater.enums.Duration;
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.github.javiersantos.appupdater.interfaces.IUpdateDisplay;
+
+import java.net.URL;
+
+public class SnackbarDisplay implements IUpdateDisplay {
+    private Snackbar snackbar;
+    private Context context;
+    String descriptionText;
+    String descriptionNoUpdateText;
+    UpdateFrom updateFrom;
+    private Duration duration;
+    URL updateUrl;
+
+    public SnackbarDisplay(Context context) {
+        this.context = context;
+        this.duration = Duration.NORMAL;
+    }
+
+    @Override
+    public void onShow() {
+        snackbar = UtilsDisplay.showUpdateAvailableSnackbar(context, descriptionText, getDurationEnumToBoolean(duration), updateFrom, updateUrl);
+        snackbar.show();
+    }
+
+    @Override
+    public void onUpdated() {
+        snackbar = UtilsDisplay.showUpdateNotAvailableSnackbar(context, descriptionNoUpdateText, getDurationEnumToBoolean(duration));
+        snackbar.show();
+    }
+
+    static Boolean getDurationEnumToBoolean(Duration duration) {
+        Boolean res = false;
+
+        switch (duration) {
+            case INDEFINITE:
+                res = true;
+                break;
+        }
+
+        return res;
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionUpdate(String text) {
+        this.descriptionText = text;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setDescriptionNoUpdate(String text) {
+        this.descriptionNoUpdateText = text;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setUpdateUrl(URL url) {
+        this.updateUrl = url;
+        return this;
+    }
+
+    @Override
+    public IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom) {
+        this.updateFrom = updateFrom;
+        return this;
+    }
+
+    @Override
+    public void dismiss() {
+        if (snackbar != null && snackbar.isShown()) {
+            snackbar.dismiss();
+        }
+    }
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/Displays/SnackbarDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/Displays/SnackbarDisplay.java
@@ -3,36 +3,30 @@ package com.github.javiersantos.appupdater.Displays;
 import android.content.Context;
 import android.support.design.widget.Snackbar;
 
+import com.github.javiersantos.appupdater.R;
 import com.github.javiersantos.appupdater.UtilsDisplay;
 import com.github.javiersantos.appupdater.enums.Duration;
-import com.github.javiersantos.appupdater.enums.UpdateFrom;
-import com.github.javiersantos.appupdater.interfaces.IUpdateDisplay;
+import com.github.javiersantos.appupdater.objects.Update;
 
-import java.net.URL;
-
-public class SnackbarDisplay implements IUpdateDisplay {
+public class SnackbarDisplay extends BaseDisplay {
     private Snackbar snackbar;
-    private Context context;
-    String descriptionText;
-    String descriptionNoUpdateText;
-    UpdateFrom updateFrom;
     private Duration duration;
-    URL updateUrl;
 
     public SnackbarDisplay(Context context) {
-        this.context = context;
+        super(context);
         this.duration = Duration.NORMAL;
     }
 
     @Override
-    public void onShow() {
-        snackbar = UtilsDisplay.showUpdateAvailableSnackbar(context, descriptionText, getDurationEnumToBoolean(duration), updateFrom, updateUrl);
+    public void onShow(Update update) {
+        setDescriptionUpdate(String.format(context.getResources().getString(R.string.appupdater_update_available_description_snackbar), update.getLatestVersion()));
+        snackbar = UtilsDisplay.showUpdateAvailableSnackbar(context, getDescriptionUpdate(), getDurationEnumToBoolean(duration), updateFrom, getUpdateUrl(update));
         snackbar.show();
     }
 
     @Override
-    public void onUpdated() {
-        snackbar = UtilsDisplay.showUpdateNotAvailableSnackbar(context, descriptionNoUpdateText, getDurationEnumToBoolean(duration));
+    public void onUpdated(Update update) {
+        snackbar = UtilsDisplay.showUpdateNotAvailableSnackbar(context, getDescriptionNoUpdate(), getDurationEnumToBoolean(duration));
         snackbar.show();
     }
 
@@ -48,27 +42,8 @@ public class SnackbarDisplay implements IUpdateDisplay {
         return res;
     }
 
-    @Override
-    public IUpdateDisplay setDescriptionUpdate(String text) {
-        this.descriptionText = text;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setDescriptionNoUpdate(String text) {
-        this.descriptionNoUpdateText = text;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setUpdateUrl(URL url) {
-        this.updateUrl = url;
-        return this;
-    }
-
-    @Override
-    public IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom) {
-        this.updateFrom = updateFrom;
+    public SnackbarDisplay setDuration(Duration duration) {
+        this.duration = duration;
         return this;
     }
 

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsDisplay.java
@@ -16,9 +16,9 @@ import com.github.javiersantos.appupdater.enums.UpdateFrom;
 
 import java.net.URL;
 
-class UtilsDisplay {
+public class UtilsDisplay {
 
-    static AlertDialog showUpdateAvailableDialog(final Context context, String title, String content, String btnNegative, String btnPositive, String btnNeutral, final DialogInterface.OnClickListener updateClickListener, final DialogInterface.OnClickListener dismissClickListener, final DialogInterface.OnClickListener disableClickListener) {
+    public static AlertDialog showUpdateAvailableDialog(final Context context, String title, String content, String btnNegative, String btnPositive, String btnNeutral, final DialogInterface.OnClickListener updateClickListener, final DialogInterface.OnClickListener dismissClickListener, final DialogInterface.OnClickListener disableClickListener) {
         return new AlertDialog.Builder(context)
                 .setTitle(title)
                 .setMessage(content)
@@ -27,7 +27,7 @@ class UtilsDisplay {
                 .setNeutralButton(btnNeutral, disableClickListener).create();
     }
 
-    static AlertDialog showUpdateNotAvailableDialog(final Context context, String title, String content) {
+    public static AlertDialog showUpdateNotAvailableDialog(final Context context, String title, String content) {
         return new AlertDialog.Builder(context)
                 .setTitle(title)
                 .setMessage(content)
@@ -38,7 +38,7 @@ class UtilsDisplay {
                 .create();
     }
 
-    static Snackbar showUpdateAvailableSnackbar(final Context context, String content, Boolean indefinite, final UpdateFrom updateFrom, final URL apk) {
+    public static Snackbar showUpdateAvailableSnackbar(final Context context, String content, Boolean indefinite, final UpdateFrom updateFrom, final URL apk) {
         Activity activity = (Activity) context;
         int snackbarTime = indefinite ? Snackbar.LENGTH_INDEFINITE : Snackbar.LENGTH_LONG;
 
@@ -58,7 +58,7 @@ class UtilsDisplay {
         return snackbar;
     }
 
-    static Snackbar showUpdateNotAvailableSnackbar(final Context context, String content, Boolean indefinite) {
+    public static Snackbar showUpdateNotAvailableSnackbar(final Context context, String content, Boolean indefinite) {
         Activity activity = (Activity) context;
         int snackbarTime = indefinite ? Snackbar.LENGTH_INDEFINITE : Snackbar.LENGTH_LONG;
 
@@ -72,7 +72,7 @@ class UtilsDisplay {
         return Snackbar.make(activity.findViewById(android.R.id.content), content, snackbarTime);
     }
 
-    static void showUpdateAvailableNotification(Context context, String title, String content, UpdateFrom updateFrom, URL apk, int smallIconResourceId) {
+    public static void showUpdateAvailableNotification(Context context, String title, String content, UpdateFrom updateFrom, URL apk, int smallIconResourceId) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         initNotificationChannel(context, notificationManager);
 
@@ -85,7 +85,7 @@ class UtilsDisplay {
         notificationManager.notify(0, builder.build());
     }
 
-    static void showUpdateNotAvailableNotification(Context context, String title, String content, int smallIconResourceId) {
+    public static void showUpdateNotAvailableNotification(Context context, String title, String content, int smallIconResourceId) {
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         initNotificationChannel(context, notificationManager);
 

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -101,17 +101,7 @@ class UtilsLibrary {
         return res;
     }
 
-    static Boolean getDurationEnumToBoolean(Duration duration) {
-        Boolean res = false;
 
-        switch (duration) {
-            case INDEFINITE:
-                res = true;
-                break;
-        }
-
-        return res;
-    }
 
     private static URL getUpdateURL(Context context, UpdateFrom updateFrom, GitHub gitHub) {
         String res;

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -40,11 +40,11 @@ public class UtilsLibrary {
         return stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : context.getString(stringId);
     }
 
-    static String getAppPackageName(Context context) {
+    public static String getAppPackageName(Context context) {
         return context.getPackageName();
     }
 
-    static String getAppInstalledVersion(Context context) {
+    public static String getAppInstalledVersion(Context context) {
         String version = "0.0.0.0";
 
         try {
@@ -56,7 +56,7 @@ public class UtilsLibrary {
         return version;
     }
 
-    static Integer getAppInstalledVersionCode(Context context) {
+    public static Integer getAppInstalledVersionCode(Context context) {
         Integer versionCode = 0;
 
         try {
@@ -103,7 +103,7 @@ public class UtilsLibrary {
 
 
 
-    private static URL getUpdateURL(Context context, UpdateFrom updateFrom, GitHub gitHub) {
+    public static URL getUpdateURL(Context context, UpdateFrom updateFrom, GitHub gitHub) {
         String res;
 
         switch (updateFrom) {
@@ -129,7 +129,7 @@ public class UtilsLibrary {
 
     }
 
-    static Update getLatestAppVersionStore(Context context, UpdateFrom updateFrom, GitHub gitHub) {
+    public static Update getLatestAppVersionStore(Context context, UpdateFrom updateFrom, GitHub gitHub) {
         switch (updateFrom) {
             case GOOGLE_PLAY:
                 return getLatestAppVersionGooglePlay(context);
@@ -138,7 +138,7 @@ public class UtilsLibrary {
         }
     }
 
-    private static Update getLatestAppVersionGooglePlay(Context context) {
+    public static Update getLatestAppVersionGooglePlay(Context context) {
         String version = "0.0.0.0";
         String recentChanges = "";
 
@@ -162,7 +162,7 @@ public class UtilsLibrary {
         return new Update(version, recentChanges, updateURL);
     }
 
-    private static String getJsoupString(String url, String css, int position) throws Exception {
+    public static String getJsoupString(String url, String css, int position) throws Exception {
         return Jsoup.connect(url)
                 .timeout(30000)
                 .userAgent("Mozilla/5.0 (Windows; U; WindowsNT 5.1; en-US; rv1.8.1.6) Gecko/20070725 Firefox/2.0.0.6")
@@ -172,7 +172,7 @@ public class UtilsLibrary {
                 .ownText();
     }
 
-    private static Update getLatestAppVersionHttp(Context context, UpdateFrom updateFrom, GitHub gitHub) {
+    public static Update getLatestAppVersionHttp(Context context, UpdateFrom updateFrom, GitHub gitHub) {
         Boolean isAvailable = false;
         String source = "";
         OkHttpClient client = new OkHttpClient();
@@ -233,7 +233,7 @@ public class UtilsLibrary {
         return new Update(version, updateUrl);
     }
 
-    private static String getVersion(UpdateFrom updateFrom, Boolean isAvailable, String source) {
+    public static String getVersion(UpdateFrom updateFrom, Boolean isAvailable, String source) {
         String version = "0.0.0.0";
         if (isAvailable) {
             switch (updateFrom) {
@@ -264,7 +264,7 @@ public class UtilsLibrary {
         return version;
     }
 
-    static Update getLatestAppVersion(UpdateFrom updateFrom, String url) {
+    public static Update getLatestAppVersion(UpdateFrom updateFrom, String url) {
         if (updateFrom == UpdateFrom.XML){
             ParserXML parser = new ParserXML(url);
             return parser.parse();
@@ -274,7 +274,7 @@ public class UtilsLibrary {
     }
 
 
-    static Intent intentToUpdate(Context context, UpdateFrom updateFrom, URL url) {
+    public static Intent intentToUpdate(Context context, UpdateFrom updateFrom, URL url) {
         Intent intent;
 
         if (updateFrom.equals(UpdateFrom.GOOGLE_PLAY)) {
@@ -286,7 +286,7 @@ public class UtilsLibrary {
         return intent;
     }
 
-    static void goToUpdate(Context context, UpdateFrom updateFrom, URL url) {
+    public static void goToUpdate(Context context, UpdateFrom updateFrom, URL url) {
         Intent intent = intentToUpdate(context, updateFrom, url);
 
         if (updateFrom.equals(UpdateFrom.GOOGLE_PLAY)) {
@@ -301,11 +301,11 @@ public class UtilsLibrary {
         }
     }
 
-    static Boolean isAbleToShow(Integer successfulChecks, Integer showEvery) {
+    public static Boolean isAbleToShow(Integer successfulChecks, Integer showEvery) {
         return successfulChecks % showEvery == 0;
     }
 
-    static Boolean isNetworkAvailable(Context context) {
+    public static Boolean isNetworkAvailable(Context context) {
         Boolean res = false;
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         if (cm != null) {

--- a/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/UtilsLibrary.java
@@ -32,9 +32,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-class UtilsLibrary {
+public class UtilsLibrary {
 
-    static String getAppName(Context context) {
+    public static String getAppName(Context context) {
         ApplicationInfo applicationInfo = context.getApplicationInfo();
         int stringId = applicationInfo.labelRes;
         return stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : context.getString(stringId);

--- a/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
@@ -1,15 +1,18 @@
 package com.github.javiersantos.appupdater.interfaces;
 
 import com.github.javiersantos.appupdater.enums.UpdateFrom;
+import com.github.javiersantos.appupdater.objects.Update;
 
 import java.net.URL;
 
 public interface IUpdateDisplay {
-    void onShow();
-    void onUpdated();
+    void onShow(Update update);
+    void onUpdated(Update update);
     IUpdateDisplay setDescriptionUpdate(String text);
     IUpdateDisplay setDescriptionNoUpdate(String text);
-    IUpdateDisplay setUpdateUrl(URL url);
     IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom);
+    String getDescriptionUpdate();
+    String getDescriptionNoUpdate();
+    URL getUpdateUrl(Update update);
     void dismiss();
 }

--- a/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
@@ -1,0 +1,15 @@
+package com.github.javiersantos.appupdater.interfaces;
+
+import com.github.javiersantos.appupdater.enums.UpdateFrom;
+
+import java.net.URL;
+
+public interface IUpdateDisplay {
+    void onShow();
+    void onUpdated();
+    IUpdateDisplay setDescriptionUpdate(String text);
+    IUpdateDisplay setDescriptionNoUpdate(String text);
+    IUpdateDisplay setUpdateUrl(URL url);
+    IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom);
+    void dismiss();
+}

--- a/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
+++ b/library/src/main/java/com/github/javiersantos/appupdater/interfaces/IUpdateDisplay.java
@@ -11,6 +11,7 @@ public interface IUpdateDisplay {
     IUpdateDisplay setDescriptionUpdate(String text);
     IUpdateDisplay setDescriptionNoUpdate(String text);
     IUpdateDisplay setUpdateFrom(UpdateFrom updateFrom);
+    UpdateFrom getUpdateFrom();
     String getDescriptionUpdate();
     String getDescriptionNoUpdate();
     URL getUpdateUrl(Update update);


### PR DESCRIPTION
Creates a interface so end user can modify or create own update display.
Converts Notification , Snackbar , Dialog into classes

adds example of custom toast display

I think functions in AppUpdater like 
- https://github.com/javiersantos/AppUpdater/blob/ca6bcd2495095d6965ddf15d6a6fea6e80fab35c/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java#L311

- https://github.com/javiersantos/AppUpdater/blob/ca6bcd2495095d6965ddf15d6a6fea6e80fab35c/library/src/main/java/com/github/javiersantos/appupdater/AppUpdater.java#L74

should be moved into own display classes.